### PR TITLE
fix. 로그인 확인을 위한 세션스토리지 키 확인 수정. #68

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,3 +1,4 @@
+import { firebaseConfig } from 'common/firebase';
 import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import SearchInput from './SearchInput';
@@ -17,7 +18,10 @@ export default function Header() {
   const navigate = useNavigate();
 
   // 로그인 확인을 위한 세션스토리지 키 확인. 키 존재? => 로그인 되어있음 / 없음 => 로그인 안 되어있음
-  const isLoggedIn = sessionStorage.key(0);
+  // const isLoggedIn = sessionStorage.key(0);
+  const isLoggedIn = sessionStorage.getItem(
+    `firebase:authUser:${firebaseConfig.apiKey}:[DEFAULT]`,
+  );
 
   const goToLogin = (): void => {
     navigate('/login');


### PR DESCRIPTION
- 기존 헤더 컴포넌트에서 세션스토리지의 첫번째 키로 로그인 유저를 확인함.
- 문제 없으나 해당 에러처럼 특정 사용자가 크롬 익스텐션과의 이슈로 잘못된 키 값을 받아와 유저 확인이 불가능할 수 있으니 세션스토리지의 파이어베이스 키 값 만을 가져오게 수정함.